### PR TITLE
Added SKIP_SYSCLK_INIT for the loader

### DIFF
--- a/targets/iMXRT/Loader2/Loader.hzp
+++ b/targets/iMXRT/Loader2/Loader.hzp
@@ -130,7 +130,7 @@
       arm_target_loader_default_loader=""
       arm_target_loader_parameter="666"
       batch_build_configurations="MIMXRT1011_Release;MIMXRT1015_Release;MIMXRT1020_Release;MIMXRT1050_Release;MIMXRT1060_Release;MIMXRT1064_Release"
-      c_preprocessor_definitions="__THUMB;FSL_DRIVER_TRANSFER_DOUBLE_WEAK_IRQ=0"
+      c_preprocessor_definitions="__THUMB;FSL_DRIVER_TRANSFER_DOUBLE_WEAK_IRQ=0;SKIP_SYSCLK_INIT"
       c_system_include_directories="$(StudioDir)/include;$(PackagesDir)/include;$(TargetsDir)/iMXRT;$(PackagesDir)/libraries/libmem_drivers"
       debug_register_definition_file="../XML/$(DeviceName)_registers.xml"
       debug_startup_completion_point="main"

--- a/targets/iMXRT/Loader2/loader.c
+++ b/targets/iMXRT/Loader2/loader.c
@@ -211,6 +211,13 @@ enum LibmemStatus Init_Libmem (libmem_driver_handle_t *handle, enum eMemoryType 
 			{
 				// Init for Octal-SPI with DDR
 				DebugPrint ("Init Loader for Octal-SPI (DDR)\r\n");
+            
+            /* A small delay is need here */
+            for(int i=0; i<1000000; i++)
+            {
+              __asm__ volatile("nop");
+            }
+            
 				InitOctaSPIPins (base);
 				status =  Libmem_InitializeDriver_xSPI (handle, base, MemType);
 				if (status != LibmemStaus_Success)


### PR DESCRIPTION
In general the Loader will switch off the SDRAM clock at start. This is a problem in case of debugging a flash session where the SDRAM clock was initialize before by the startup script. This can be prevented by using the SKIP_SYSCLK_INIT switch. However, it must be ensure that the clock is initialized before the Loader using the startup script.