### PR TITLE
Added small delay in case of a octo flash

### DIFF
--- a/targets/iMXRT/Loader2/loader.c
+++ b/targets/iMXRT/Loader2/loader.c
@@ -211,6 +211,13 @@ enum LibmemStatus Init_Libmem (libmem_driver_handle_t *handle, enum eMemoryType 
 			{
 				// Init for Octal-SPI with DDR
 				DebugPrint ("Init Loader for Octal-SPI (DDR)\r\n");
+            
+            /* A small delay is need here */
+            for(int i=0; i<1000000; i++)
+            {
+              __asm__ volatile("nop");
+            }
+            
 				InitOctaSPIPins (base);
 				status =  Libmem_InitializeDriver_xSPI (handle, base, MemType);
 				if (status != LibmemStaus_Success)


### PR DESCRIPTION
I use a RT1062 CPU with octo flash.

When debugging in Flash the download only works every second time for me. The
error message is:

Erase failed
Memory erase operation failed: no driver installed for memory range

But when the loader is compiled with debug output, it works here every time.
It looks like a small delay is needed to make the download work every time.